### PR TITLE
Feature/inverse dependencies

### DIFF
--- a/src/demorepo/commands/command_run.py
+++ b/src/demorepo/commands/command_run.py
@@ -131,11 +131,12 @@ def run(args):
     command = args['command']
     targets = args.get('targets', None)
     reverse_targets = args['reverse_targets']
+    reverse_dependency = args['reverse_dependency']
     env = args.get('env')
 
     projects = config.get_projects()
     dependencies = config.get_projects_dependencies()
     paths = config.get_projects_paths()
 
-    targets = get_targets(projects, dependencies, targets, reverse_targets)
+    targets = get_targets(projects, dependencies, targets, reverse_targets, reverse_dependency)
     _run_targets(projects, paths, targets, env, command=command)

--- a/src/demorepo/commands/targets/__init__.py
+++ b/src/demorepo/commands/targets/__init__.py
@@ -1,10 +1,12 @@
+from collections import defaultdict
+
 from demorepo import logger
 
 
 __all__ = ['get_targets']
 
 
-def get_targets(targets, dependencies, targets_filter, reverse_targets=False, recursive_deps=False):
+def get_targets(targets, dependencies, targets_filter, reverse_targets=False, inverse_dependencies=False):
 
     if targets_filter is not None:
         # If filter is empty it means that we will return an empty list so nothing gets run
@@ -21,11 +23,15 @@ def get_targets(targets, dependencies, targets_filter, reverse_targets=False, re
                         "Unrecognized project {} in --targets".format(t))
             targets = [t for t in targets if t in targets_filter]
 
+    # Set reverse dependency targets if inverse_dependencies
+    if inverse_dependencies:
+        targets = _add_inverse_dependencies(targets, dependencies)
+
     # Set target order
     targets = _order_targets(targets, dependencies)
 
     # Reverse if specified in args
-    if (reverse_targets):
+    if reverse_targets:
         targets.reverse()
 
     logger.info("Target projects are: {}".format(targets))
@@ -51,6 +57,27 @@ def _order_targets(targets, dependencies):
     return list(ordered)
 
 
-def _add_deps(targets, dependencies, projects):
-    # TODO: Implement inverse dependencies with projects
-    pass
+def _add_inverse_dependencies(targets, dependencies):
+    # Process the dict of dependents (projects which are dependent of a project; inverse of dependencies)
+    dependents = defaultdict(set)
+    for project in dependencies:
+        for dependency in dependencies[project]:
+            dependents[dependency].add(project)
+
+    # This recursive function add the dependencies in the set s when e is marked as modified
+    def add_dependencies(e, s):
+        new_elements = [x for x in dependents[e] if x not in s]
+        for n in new_elements:
+            s.add(n)
+            add_dependencies(n, s)
+
+    # Now, for each modified project, get its name (to use the dependents dict) and add its dependencies
+    s = set()
+    for m in targets:
+        s.add(m)
+        # only if project is in dependents list (recursive option implemented for this project type)
+        if m in dependents:
+            add_dependencies(m, s)
+
+    # Return the extended list of target projects
+    return list(s)

--- a/src/demorepo/config/__init__.py
+++ b/src/demorepo/config/__init__.py
@@ -82,7 +82,7 @@ def _init_config():
         _config['stages'] = stages
 
     else:
-        logger.error("Error: Unable to find config.yml. Is this a demorepo?")
+        logger.error("Error: Unable to find demorepo.yml. Is this a demorepo?")
         sys.exit(-1)
 
 

--- a/src/demorepo/parser/__init__.py
+++ b/src/demorepo/parser/__init__.py
@@ -43,9 +43,9 @@ parser_stage.add_argument(
 parser_stage.add_argument('-e', '--env', action='append', help='Optional variables passed to the target stage script.'
                           ' The format is VAR_NAME=VAR_VALUE. '
                           'Multiple env vars can be specified.')
-# parser_stage.add_argument('-r', '--recursive-deps', action='store_true',
-#                               help='Find projects recursively which depends on target projects and include them as '
-#                               'target projects too.')
+parser_stage.add_argument('-r', '--inverse-dependencies', action='store_true',
+                          help='Find projects which depends on target projects and include them as '
+                               'target projects too.')
 parser_stage.add_argument('-t', '--targets', help='A list of target project names to run the provided stage, '
                           'separated by blank spaces (use quotes around the string).')
 parser_stage.add_argument('--reverse-targets', action='store_true',
@@ -63,9 +63,9 @@ parser_run.add_argument('-e', '--env', action='append',
                         help='Optional variables passed to the target stage script.'
                         ' The format is VAR_NAME=VAR_VALUE. '
                         'Multiple env vars can be specified.')
-# parser_run.add_argument('-r', '--recursive-deps', action='store_true',
-#                               help='Find projects recursively which depends on target projects and include them as '
-#                                    'target projects too.')
+parser_run.add_argument('-r', '--inverse-dependencies', action='store_true',
+                        help='Find projects which depends on target projects and include them as '
+                             'target projects too.')
 parser_run.add_argument('--reverse-targets', action='store_true',
                         help='Reverse the dependency order for projects')
 

--- a/src/tests/test_parser.py
+++ b/src/tests/test_parser.py
@@ -6,8 +6,8 @@ from demorepo import parser
 
 defaults = dict(silent=False, log_path=None, working_mode=None)
 lgc_defaults = dict(ci_tool='gitlab', ci_url=None)
-run_defaults = dict(targets=None, env=None, reverse_targets=False)
-stage_defaults = dict(targets=None, env=None, reverse_targets=False)
+run_defaults = dict(targets=None, env=None, reverse_targets=False, inverse_dependencies=False)
+stage_defaults = dict(targets=None, env=None, reverse_targets=False, inverse_dependencies=False)
 
 
 @pytest.mark.parametrize("argv,expected,exit", [
@@ -45,7 +45,7 @@ stage_defaults = dict(targets=None, env=None, reverse_targets=False)
     # run required
     (
         ['demorepo', 'run', 'ls'],
-        dict(defaults, working_mode='run', **run_defaults, command='ls'),
+        dict(defaults, working_mode='run', command='ls', **run_defaults),
         None,
     ),
     # run required fail
@@ -56,14 +56,16 @@ stage_defaults = dict(targets=None, env=None, reverse_targets=False)
     ),
     # run opts
     (
-        ['demorepo', 'run', 'ls', '--targets', 'target1', '--reverse-targets', '--env', 'cosa=1234'],
-        dict(defaults, working_mode='run', command='ls', targets='target1', reverse_targets=True, env=['cosa=1234']),
+        ['demorepo', 'run', 'ls', '--targets', 'target1', '--reverse-targets',
+         '--env', 'cosa=1234', '--inverse-dependencies'],
+        dict(defaults, working_mode='run', command='ls', targets='target1',
+             reverse_targets=True, env=['cosa=1234'], inverse_dependencies=True),
         None,
     ),
     # stage required
     (
         ['demorepo', 'stage', 'deploy'],
-        dict(defaults, working_mode='stage', **stage_defaults, stage='deploy'),
+        dict(defaults, working_mode='stage', stage='deploy', **stage_defaults),
         None,
     ),
     # stage required fail
@@ -74,9 +76,10 @@ stage_defaults = dict(targets=None, env=None, reverse_targets=False)
     ),
     # stage opts
     (
-        ['demorepo', 'stage', 'deploy', '--targets', 'target1', '--reverse-targets', '--env', 'cosa=1234'],
-        dict(defaults, working_mode='stage', stage='deploy',
-             targets='target1', reverse_targets=True, env=['cosa=1234']),
+        ['demorepo', 'stage', 'deploy', '--targets', 'target1', '--reverse-targets',
+         '--env', 'cosa=1234', '--inverse-dependencies'],
+        dict(defaults, working_mode='stage', stage='deploy', targets='target1',
+             reverse_targets=True, env=['cosa=1234'], inverse_dependencies=True),
         None,
     ),
 ])

--- a/src/tests/test_targets.py
+++ b/src/tests/test_targets.py
@@ -13,12 +13,13 @@ from . import raises
 """
 
 
-@pytest.mark.parametrize("projects, dependencies, targets, reverse_targets, expected, exception", [
+@pytest.mark.parametrize("projects, dependencies, targets, reverse_targets, inverse_dependencies, expected, exception", [
     # No filter no deps
     (
         ["target_A", "target_B", "target_C"],
         dict(target_A=[], target_B=[], target_C=[]),
         "target_A target_B target_C",
+        False,
         False,
         ["target_A", "target_B", "target_C"],
         None
@@ -29,6 +30,7 @@ from . import raises
         dict(target_A=[], target_B=[], target_C=[]),
         "target_A target_C",
         False,
+        False,
         ["target_A", "target_C"],
         None
     ),
@@ -37,6 +39,7 @@ from . import raises
         ["target_A", "target_B", "target_C"],
         dict(target_A=[], target_B=[], target_C=[]),
         "",
+        False,
         False,
         [],
         None
@@ -47,6 +50,7 @@ from . import raises
         dict(target_A=[], target_B=[], target_C=[]),
         "target_A target_D",
         False,
+        False,
         None,
         Exception
     ),
@@ -55,6 +59,7 @@ from . import raises
         ["target_A", "target_B", "target_C"],
         dict(target_A=["target_B"], target_B=[], target_C=["target_A"]),
         "target_A target_B target_C",
+        False,
         False,
         ["target_B", "target_A", "target_C"],
         None
@@ -65,6 +70,7 @@ from . import raises
         dict(target_A=["target_B"], target_B=[], target_C=["target_A"]),
         "target_A target_C",
         False,
+        False,
         ["target_A", "target_C"],
         None
     ),
@@ -74,6 +80,7 @@ from . import raises
         dict(target_A=["target_B"], target_B=[], target_C=["target_A"]),
         "target_A target_B target_C",
         True,
+        False,
         ["target_C", "target_A", "target_B"],
         None
     ),
@@ -83,7 +90,28 @@ from . import raises
         dict(target_A=["target_B"], target_B=[], target_C=["target_A"]),
         "target_B target_C",
         True,
+        False,
         ["target_C", "target_B"],
+        None
+    ),
+    # No reverse order, inverse deps (single iteration A -> B)
+    (
+        ["target_A", "target_B", "target_C"],
+        dict(target_A=["target_B"], target_B=[], target_C=[]),
+        "target_B",
+        False,
+        True,
+        ["target_B", "target_A"],
+        None
+    ),
+    # Reverse order, inverse deps (multiple iterations B -> C -> A)
+    (
+        ["target_A", "target_B", "target_C"],
+        dict(target_A=["target_C"], target_B=[], target_C=["target_B"]),
+        "target_B",
+        True,
+        True,
+        ["target_A", "target_C", "target_B"],
         None
     ),
     # Cycle
@@ -93,11 +121,12 @@ from . import raises
              "target_A"], target_C=["target_A"]),
         "target_A target_B target_C",
         False,
+        False,
         None,
         Exception
     ),
 ])
-def test_get_targets_plain(projects, dependencies, targets, reverse_targets, expected, exception):
+def test_get_targets_plain(projects, dependencies, targets, reverse_targets, inverse_dependencies, expected, exception):
     with raises(exception):
-        result = get_targets(projects, dependencies, targets, reverse_targets)
+        result = get_targets(projects, dependencies, targets, reverse_targets, inverse_dependencies)
         assert result == expected


### PR DESCRIPTION
feat: Implemented inverse dependencies argument for run and run-stage commands

    It computes inverse dependencies, and include such type of deps from targets as
    new targets. For example, if A depends on B, and B is the target list, this option
    extends the targets list to be A and B.

    Closes #36